### PR TITLE
chore: bump ospo-reusable-workflows release.yaml to v1.0.1

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -8,6 +8,9 @@ template: |
   See details of [all code changes](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION) since previous release
 
 categories:
+  - title: "💥 Breaking Changes"
+    labels:
+      - "breaking"
   - title: "🚀 Features"
     labels:
       - "feature"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       id-token: write       # Federate for artifact attestation
       attestations: write   # Generate build provenance attestations
       discussions: write    # Create release announcement discussion
-    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@592067a69a43d2285f933753d89a7c9d51b96530 # v1.0.0
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@e92cb6053ace495fe40a5f185988557afcdcecbc # v1.0.1
     with:
       publish: true
       release-config-name: release-drafter.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,12 @@ on:
 jobs:
   release:
     permissions:
-      contents: write
-      pull-requests: read
+      contents: write       # Create release and push tags
+      pull-requests: read   # Read PR labels for release-drafter
+      packages: write       # Push container image to ghcr.io
+      id-token: write       # Federate for artifact attestation
+      attestations: write   # Generate build provenance attestations
+      discussions: write    # Create release announcement discussion
     uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@592067a69a43d2285f933753d89a7c9d51b96530 # v1.0.0
     with:
       publish: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,73 +10,9 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
-    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@a0cf79bd8756e0a9c1555bf4975eae7ce7a8e8dc # v0.6.0
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@592067a69a43d2285f933753d89a7c9d51b96530 # v1.0.0
     with:
       publish: true
       release-config-name: release-drafter.yml
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
-  goreleaser:
-    needs: release
-    runs-on: ubuntu-latest
-    permissions:
-      attestations: write
-      contents: write
-      id-token: write
-    outputs:
-      attestation_matrix: ${{ steps.generate_matrix.outputs.matrix }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-      - name: Install Syft
-        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
-        with:
-          syft-version: v1.33.0
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # v7.1.0
-        with:
-          distribution: goreleaser
-          version: "~> v2"
-          args: release --clean
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Attest Build Provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
-        with:
-          subject-checksums: dist/checksums.txt
-      - name: Generate attestation matrix
-        id: generate_matrix
-        run: |
-          matrix=$(ls dist/*.spdx.json | jq -R '{"sbom": ., "archive": sub("\\.spdx\\.json$"; "")}' | jq -s -c '{"include": .}')
-          echo "matrix=$matrix" >> $GITHUB_OUTPUT
-      - name: Upload artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: dist
-          path: dist
-  attest-sboms:
-    needs: goreleaser
-    runs-on: ubuntu-latest
-    permissions:
-      attestations: write
-      id-token: write
-    strategy:
-      matrix: ${{ fromJson(needs.goreleaser.outputs.attestation_matrix) }}
-    steps:
-      - name: Download artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: dist
-          path: dist
-      - name: Attest SBOM
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
-        with:
-          subject-path: "${{ matrix.archive }}"
-          sbom-path: "${{ matrix.sbom }}"


### PR DESCRIPTION
## What

Pin the reusable release workflow to v1.0.0 (SHA 592067a69a43d2285f933753d89a7c9d51b96530). Add a Breaking Changes category to release-drafter.

## Why

v1.0.0 of ospo-reusable-workflows broadens the release trigger to include breaking, feature, vuln, and release labels and folds GoReleaser, container image build, attestation, and discussion creation into the reusable workflow itself. Surfacing breaking changes prominently in release notes aligns the changelog with the new label-based release triggers.

## Notes

- The outer label-filter `if:` block on the release job is removed because the v1.0 reusable workflow now handles label filtering internally.
- Trigger updated to `pull_request_target` so the workflow can push tags via `GITHUB_TOKEN`.
- The local `goreleaser` and `attest-sboms` jobs have been dropped; the v1.0 reusable workflow handles GoReleaser, attestation, and SBOM publishing internally. This repo currently has no `.goreleaser.yml`, so confirm the reusable workflow either gates GoReleaser on the presence of a config or that this repo does not need release artifacts.

## Testing

- [ ] Confirm Actions parses the new workflow with no syntax errors.
- [ ] After merge, open a labeled PR (e.g. `feature` or `breaking`) and verify the reusable workflow drafts/publishes a release as expected.
- [ ] Verify the Breaking Changes section renders in the next drafted release notes when a PR carries the `breaking` label.